### PR TITLE
Fixed units, as HA (via MQTT) complains that they are not as expected

### DIFF
--- a/core/src/main/java/pmstation/core/plantower/Unit.java
+++ b/core/src/main/java/pmstation/core/plantower/Unit.java
@@ -1,10 +1,10 @@
 package pmstation.core.plantower;
 
 public enum Unit {
-    PARTICULATE_MATTER("\u03BCg/m\u00B3"),
-    HCHO_UG("\u03BCg/m\u00B3"),
-    HCHO_MG("mg/m\u00B3"),
-    TEMPERATURE("\u2103"),
+    PARTICULATE_MATTER("\u00B5g/m\u00B3"), // µg/m³
+    HCHO_UG("\u00B5g/m\u00B3"), // µg/m³
+    HCHO_MG("mg/m\u00B3"), // mg/m³
+    TEMPERATURE("\u00B0C"), // °C
     HUMIDITY("%"),
     ;
 


### PR DESCRIPTION
When sending reading to MQTT broker, Home Assistant says in logs:

```
2025-04-24 23:09:19.018 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.pm_home_station_pm2_5 (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement 'μg/m³' which is not a valid unit for the device class ('pm25') it is using; expected one of ['µg/m³']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
2025-04-24 23:09:19.021 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.pm_home_station_temperature (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement '℃' which is not a valid unit for the device class ('temperature') it is using; expected one of ['°F', 'K', '°C']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22
```

Different UTF-8 characters must be used, even if they look the same in the above log /they must be hex previewed to see the difference/.